### PR TITLE
・軽微なバグを修正

### DIFF
--- a/base/Sprite.cpp
+++ b/base/Sprite.cpp
@@ -40,7 +40,7 @@ void Sprite::Update(Matrix4x4 viewMatrix) {
 
 	//---------------------------------------
 	// テクスチャ範囲の反映
-	//ReflectTextureRange();
+	ReflectTextureRange();
 
 	//---------------------------------------
 	// アンカーポイントの反映
@@ -253,9 +253,9 @@ void Sprite::ReflectTextureRange() {
 
 	//テクスチャの左上座標を取得
 	float textureLeft = textureLeftTop_.x / textureWidth;
-	float textureRight = ( textureLeftTop_.x + size_.x ) / textureWidth;
+	float textureRight = ( textureLeftTop_.x + textureSize_.x ) / textureWidth;
 	float textureTop = textureLeftTop_.y / textureHeight;	
-	float textureBottom = ( textureLeftTop_.y + size_.y ) / textureHeight;
+	float textureBottom = ( textureLeftTop_.y + textureSize_.y ) / textureHeight;
 
 	//頂点リソースにデータを書き込む
 	vertexData_[0].texCoord = { textureLeft, textureBottom };

--- a/base/Sprite.h
+++ b/base/Sprite.h
@@ -321,7 +321,5 @@ private:
 	Vector2 textureLeftTop_ = { 0.0f,0.0f };
 	//テクスチャ切り出しサイズ
 	Vector2 textureSize_ = { 0.0f,0.0f };
-
-
 };
 

--- a/imgui.ini
+++ b/imgui.ini
@@ -14,7 +14,7 @@ Size=301,724
 Collapsed=0
 
 [Window][2D Object]
-Pos=1067,20
+Pos=1080,20
 Size=211,696
 Collapsed=0
 


### PR DESCRIPTION
This pull request includes several changes to the `Sprite` class and related methods to fix texture coordinate calculations, as well as a minor update to the `imgui.ini` file.

**Changes to `Sprite` class and methods:**

* [`base/Sprite.cpp`](diffhunk://#diff-47a49effae204c3672afc741240718e9da248b70f05009889ee256090a3e3444L43-R43): Enabled the `ReflectTextureRange` method call in the `Update` method.
* [`base/Sprite.cpp`](diffhunk://#diff-47a49effae204c3672afc741240718e9da248b70f05009889ee256090a3e3444L256-R258): Corrected the texture coordinate calculations in the `ReflectTextureRange` method by using `textureSize_` instead of `size_`.
* [`base/Sprite.h`](diffhunk://#diff-7a8e5ca6e0a4cd80a553aaac3b564d62bfcd6a97a6875830e756ae7f291b52e1L324-L325): Added a `textureSize_` member variable to the `Sprite` class to store the texture size.

**Changes to configuration:**

* [`imgui.ini`](diffhunk://#diff-31ffbf94184efe8cd19f91bd4dc81dc9ccba29f11c6dfe297939f51986a100faL17-R17): Adjusted the position of the `[Window][2D Object]` in the configuration file.