### PR TITLE
変数初期化、エラーチェック追加、フォーマット統一

### DIFF
--- a/engine/3d/Model.cpp
+++ b/engine/3d/Model.cpp
@@ -117,43 +117,45 @@ void Model::LoadObjFile(const std::string& directoryPath, const std::string& fil
 		//---------------------------------------
 		// identifierに応じた処理
 		if(identifier == "v") {
-			Vector4 position;
+			//初期化
+			Vector4 position = { 0.0f, 0.0f, 0.0f, 1.0f };
 			s >> position.x >> position.y >> position.z;
 			position.w = 1.0f; //NOTE:同次座標を送っているためw=1
 			position.x *= -1.0f; //反転
 			positions.push_back(position);
 
 		} else if(identifier == "vt") {
-			Vector2 texcoord;
+			Vector2 texcoord = { 0.0f, 0.0f };
 			s >> texcoord.x >> texcoord.y;
 			texcoord.y = 1.0f - texcoord.y; // y軸を反転
 			texcoords.push_back(texcoord);
 
 		} else if(identifier == "vn") {
-			Vector3 normal;
+			Vector3 normal = { 0.0f, 0.0f, 0.0f };
 			s >> normal.x >> normal.y >> normal.z;
 			normal.x *= -1.0f; //反転
 			normals.push_back(normal);
 
 		} else if(identifier == "f") {
-			VertexData triangle[3];
+			VertexData triangle[3] = {};
 			//面は三角形限定。その他は未対応
 			for(int32_t faceVertex = 0; faceVertex < 3; ++faceVertex) {
 				std::string vertexDefinition;
 				s >> vertexDefinition;
 				//頂点の要素へのIndexは「位置/UV/法線」で格納されているので、分解してIndexを取得する
 				std::istringstream v(vertexDefinition);
-				uint32_t elementIndices[3];
+				uint32_t elementIndices[3] = {};
 				for(int32_t element = 0; element < 3; ++element) {
 					std::string index;
 					std::getline(v, index, '/'); // /区切りでインデックスを読んでいく
 					elementIndices[element] = std::stoi(index);
 				}
 				//要素へのIndexから、実際の値を取得して、頂点を構築する
-				//NOTE:1始まりなので添字として利用するときは-1を忘れに
-				Vector4 position = positions[elementIndices[0] - 1];
-				Vector2 texcoord = texcoords[elementIndices[1] - 1];
-				Vector3 normal = normals[elementIndices[2] - 1];
+				// NOTE:1始まりなので添字として利用するときは-1を忘れに
+				// NOTE:static_cast<std::vector<Vector4, std::allocator<Vector4>>::size_type>はstd::vectorのサイズを取得する型変換
+				Vector4 position = positions[static_cast<std::vector<Vector4, std::allocator<Vector4>>::size_type>( elementIndices[0] ) - 1];
+				Vector2 texcoord = texcoords[static_cast<std::vector<Vector2, std::allocator<Vector2>>::size_type>( elementIndices[1] ) - 1];
+				Vector3 normal = normals[static_cast<std::vector<Vector3, std::allocator<Vector3>>::size_type>( elementIndices[2] ) - 1];
 				triangle[faceVertex] = { position, texcoord, normal };
 			}
 			modelData.vertices.push_back(triangle[2]);
@@ -164,7 +166,7 @@ void Model::LoadObjFile(const std::string& directoryPath, const std::string& fil
 			//MaterialTemplateLibraryファイルの名前を取得する
 			std::string materialFilename;
 			s >> materialFilename;
-			//基本的にobjファイルと同１改装にmtlは存在させるので、ディレクトリ名とファイル名を渡す
+			// NOTE:基本的にobjファイルと同１改装にmtlは存在させるので、ディレクトリ名とファイル名を渡す
 			modelData.material = LoadMaterialTemplateFile(directoryPath, materialFilename);
 		}
 	}

--- a/engine/3d/Object3d.cpp
+++ b/engine/3d/Object3d.cpp
@@ -87,7 +87,7 @@ void Object3d::CreateTransformationMatrixBuffer() {
 	//wvp用のリソースを作る
 	transfomationMatrixBuffer_ = object3dSetup_->GetDXManager()->CreateBufferResource(sizeof(TransformationMatrix));
 	//書き込み用変数
-	TransformationMatrix transformationMatrix;
+	TransformationMatrix transformationMatrix = {};
 	//書き込むためのアドレスを取得
 	transfomationMatrixBuffer_->Map(0, nullptr, reinterpret_cast<void**>( &transformationMatrixData_ ));
 	//書き込み

--- a/engine/3d/Object3d.h
+++ b/engine/3d/Object3d.h
@@ -137,8 +137,8 @@ private:
 
 	//--------------------------------------
 	// Transform
-	Transform transform_;
+	Transform transform_ = {};
 	// カメラのTransform
-	Transform cameraTransform_;
+	Transform cameraTransform_ = {};
 };
 

--- a/engine/base/DirectXCore.h
+++ b/engine/base/DirectXCore.h
@@ -377,7 +377,7 @@ public:
 	 * \return
 	 * \note
 	 */
-	HRESULT GetHr() { return hr_; }
+	HRESULT GetHr() const { return hr_; }
 
 	/**----------------------------------------------------------------------------
 	 * \brief  SetDevice デバイスの設定
@@ -412,14 +412,14 @@ public:
 	 * \return
 	 * \note
 	 */
-	DXGI_SWAP_CHAIN_DESC1 GetSwapChainDesc() { return swapChainDesc_; }
+	DXGI_SWAP_CHAIN_DESC1 GetSwapChainDesc() const { return swapChainDesc_; }
 
 	/**----------------------------------------------------------------------------
 	 * \brief  GetRtvDesc RTVディスクリプタの取得
 	 * \return
 	 * \note
 	 */
-	D3D12_RENDER_TARGET_VIEW_DESC GetRtvDesc() { return rtvDesc_; }
+	D3D12_RENDER_TARGET_VIEW_DESC GetRtvDesc() const { return rtvDesc_; }
 
 	/**----------------------------------------------------------------------------
 	 * \brief  GetRtvDescriptorHeap RTVディスクリプタヒープの取得

--- a/engine/base/WinApp.h
+++ b/engine/base/WinApp.h
@@ -58,10 +58,10 @@ private:
 	WNDCLASS wc_{};
 
 	/// ===WRC=== ///
-	RECT wrc_;
+	RECT wrc_{};
 
 	/// ===ウィンドウハンドル=== ///
-	HWND hwnd_;
+	HWND hwnd_{};
 
 };
 

--- a/imgui.ini
+++ b/imgui.ini
@@ -14,9 +14,9 @@ Size=301,724
 Collapsed=0
 
 [Window][2D Object]
-Pos=1065,25
+Pos=1066,20
 Size=211,696
-Collapsed=0
+Collapsed=1
 
 [Window][3D Object]
 Pos=1067,0

--- a/main.cpp
+++ b/main.cpp
@@ -107,30 +107,22 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 
 	// 複数枚描画用
 	std::vector<std::unique_ptr<Sprite>> sprites;
-	for(uint32_t i = 0; i < 5; ++i) {
-		for(uint32_t i = 0; i < 5; ++i) {
-			std::unique_ptr<Sprite> sprite = std::make_unique<Sprite>();
-			if(i % 2 == 0) {
-				sprite->Initialize(spriteSetup.get(), "resources/monsterBall.png");
+	// 設定
+	for(uint32_t row = 0; row < 5; ++row) {
+		for(uint32_t col = 0; col < 5; ++col) {
+			std::unique_ptr<Sprite> spriteSet = std::make_unique<Sprite>();
+			if(col % 2 == 0) {
+				spriteSet->Initialize(spriteSetup.get(), "resources/monsterBall.png");
 				//サイズ
-				sprite->SetSize({ 256.0f,256.0f });
+				spriteSet->SetSize({ 256.0f,256.0f });
 			} else {
-				sprite->Initialize(spriteSetup.get(), "resources/uvChecker.png");
+				spriteSet->Initialize(spriteSetup.get(), "resources/uvChecker.png");
 				//サイズ
-				sprite->SetSize({ 256.0f,256.0f });
+				spriteSet->SetSize({ 256.0f,256.0f });
 			}
-			sprites.push_back(std::move(sprite));
+			sprites.push_back(std::move(spriteSet));
 		}
-		// ユニークポインタでスプライトを作成
-		//NOTE:autoを使用せず明示的を心がけろ
-		std::unique_ptr<Sprite> sprite = std::make_unique<Sprite>();
-		sprite->Initialize(spriteSetup.get(), "resources/uvChecker.png");
-
-		// std::move で vector に追加
-		//NOTE:unique_ptr はコピーができないので、std::move を使ってオーナーシップを移動させる必要がある
-		sprites.push_back(std::move(sprite));
 	}
-
 
 	//TODO:06_03にて実装
 	///--------------------------------------------------------------
@@ -281,12 +273,12 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 			//NOTE:中身の分だけfor文を回す
 			float offset = 100.0f;//ずらす距離
 			int index = 0;
-			for(const auto& sprite : sprites) {
+			for(const auto& spriteSet : sprites) {
 				// スプライトを更新 (operator-> でアクセス)
-				sprite->Update();
-				sprite->SetSize(Vector2{ 128.0f,128.0f });
-				sprite->SetRotation(sprite->GetRotation() + spritesRotate);
-				sprite->SetPosition(Vector2{ index * offset, 1.0f });
+				spriteSet->Update();
+				spriteSet->SetSize(Vector2{ 128.0f,128.0f });
+				spriteSet->SetRotation(spriteSet->GetRotation() + spritesRotate);
+				spriteSet->SetPosition(Vector2{ index * offset, 1.0f });
 				index++;
 			}
 
@@ -323,9 +315,9 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 			//Spriteクラス
 			sprite->Draw();
 			//複数枚描画
-			for(const auto& sprite : sprites) {
+			for(const auto& spriteSet : sprites) {
 				// スプライトを描画
-				sprite->Draw();
+				spriteSet->Draw();
 			}
 
 			//========================================


### PR DESCRIPTION
`Model.cpp` の `Model::LoadObjFile` 関数で未初期化の変数を初期化し、型変換を追加しました。`Object3d.cpp` と `Object3d.h` で変数を初期化しました。`DirectXCore.cpp` でファイルヘッダーコメントを修正し、条件文のフォーマットを統一しました。また、複数の関数でエラーチェックを追加・改善し、変数の初期化を行いました。`DirectXCore.h` の関数に `const` 修飾を追加しました。`WinApp.h` でプライベートメンバーを初期化しました。`imgui.ini` のウィンドウ位置とサイズを変更しました。`main.cpp` でスプライトの初期化と描画処理を改善し、変数名を変更しました。