### PR TITLE
型の不一致を修正し、Initialize関数の引数を削除

### DIFF
--- a/engine/2d/Emit.cpp
+++ b/engine/2d/Emit.cpp
@@ -29,7 +29,7 @@ void Emit::Update() {
         // 中心からランダムにゆっくりと広がるようにパーティクルの位置を設定
         std::random_device rd;
         std::mt19937 gen(rd());
-        std::uniform_real_distribution<float> distAngle(0.0f, 2 * M_PI);
+        std::uniform_real_distribution<float> distAngle(0.0f, 2 * static_cast<float>(M_PI));
         std::uniform_real_distribution<float> distRadius(0.0f, 0.5f); // 半径の範囲を小さくしてゆっくり広がるようにする
     
         float radiusStep = 0.05f; // ステップを小さくしてゆっくり広がるようにする

--- a/engine/2d/ParticleManager.cpp
+++ b/engine/2d/ParticleManager.cpp
@@ -28,7 +28,7 @@ ParticleManager* ParticleManager::GetInstance() {
 
 ///=============================================================================
 ///						初期化
-void ParticleManager::Initialize(DirectXCore* dxCore, const std::string& textureDirectoryPath, SrvSetup* srvSetup) {
+void ParticleManager::Initialize(DirectXCore* dxCore, SrvSetup* srvSetup) {
 	///--------------------------------------------------------------
 	///						 Setup
 	//---------------------------------------
@@ -203,7 +203,7 @@ void ParticleManager::CreatePathcleGroup(const std::string& groupName, const std
 		particleGroups_[groupName].textureSrvIndex,
 		texture.Get(),
 		image.GetMetadata().format,
-		image.GetMetadata().mipLevels
+		static_cast<UINT>(image.GetMetadata().mipLevels)
 	);
 
 	interMediateResource = dxCore_->UploadTextureData(texture, image);

--- a/engine/2d/ParticleManager.h
+++ b/engine/2d/ParticleManager.h
@@ -65,7 +65,7 @@ public:
 	static ParticleManager* GetInstance();
 
 	/// \brief 初期化
-	void Initialize(DirectXCore* dxCore, const std::string& textureDirectoryPath, SrvSetup* srvSetup);
+	void Initialize(DirectXCore* dxCore, SrvSetup* srvSetup);
 
 	void Finalize();
 


### PR DESCRIPTION
Emit.cppのUpdate関数でM_PIをfloatにキャストし、型の不一致を防止。
ParticleManager.cppとParticleManager.hでInitialize関数のシグネチャから textureDirectoryPath引数を削除。
ParticleManager.cppのCreatePathcleGroup関数でmipLevelsをUINTにキャストし、 型の不一致を防止。