### PR TITLE
12/12

### DIFF
--- a/engine/2d/Particle.cpp
+++ b/engine/2d/Particle.cpp
@@ -148,15 +148,16 @@ void Particle::Draw() {
 		Vector2 textureLeftTop = group.second.textureLeftTop;
 		Vector2 textureSize = group.second.textureSize;
 
-		for(auto& particle : group.second.particleList) {
+		// TODO: マテリアルデータの設定を行う後に修正
+		//for(auto& particle : group.second.particleList) {
 			// UV座標の計算
-			float uStart = textureLeftTop.x / textureSize.x;
-			float uEnd = ( textureLeftTop.x + textureSize.x ) / textureSize.x;
-			float vStart = textureLeftTop.y / textureSize.y;
-			float vEnd = ( textureLeftTop.y + textureSize.y ) / textureSize.y;
+			//float uStart = textureLeftTop.x / textureSize.x;
+			//float uEnd = ( textureLeftTop.x + textureSize.x ) / textureSize.x;
+			//float vStart = textureLeftTop.y / textureSize.y;
+			//float vEnd = ( textureLeftTop.y + textureSize.y ) / textureSize.y;
 
 			// 必要であればUV座標を設定する処理を追加
-		}
+		//}
 
 		//マテリアルCBufferの場所を設定
 		commandList->SetGraphicsRootConstantBufferView(0, materialBuffer_->GetGPUVirtualAddress());
@@ -204,7 +205,7 @@ void Particle::Emit(const std::string name, const Vector3& position, uint32_t co
 
 ///=============================================================================
 ///						パーティクルグループ
-void Particle::CreateParticleGroup(const std::string& name, const std::string& textureFilePath, uint32_t maxInstanceCount) {
+void Particle::CreateParticleGroup(const std::string& name, const std::string& textureFilePath/*, uint32_t maxInstanceCount*/) {
 	// 登録済みの名前かチェックして assert
 	bool nameExists = false;
 	for(auto it = particleGroups.begin(); it != particleGroups.end(); ++it) {
@@ -336,7 +337,7 @@ ParticleStr Particle::CreateNewParticle(std::mt19937& randomEngine, const Vector
 	std::uniform_real_distribution<float> distSpeed(velocityRange_.min, velocityRange_.max);
 
 	// 新たなパーティクルの生成
-	ParticleStr particle;
+	ParticleStr particle = {};
 
 	particle.transform.scale = { 1.0f, 1.0f, 1.0f };
 	particle.transform.rotate = { 0.0f, 0.0f, 0.0f };

--- a/engine/2d/Particle.h
+++ b/engine/2d/Particle.h
@@ -47,11 +47,11 @@ struct ParticleForGPU {
 struct ParticleGroup {
 	// マテリアルデータ
 	std::string materialFilePath;
-	int srvIndex;
+	int srvIndex = 0;
 	// パーティクルのリスト (std::list<ParticleStr>型)
-	std::list<ParticleStr> particleList;
+	std::list<ParticleStr> particleList = {};
 	// インスタンシングデータ用SRVインデックス
-	int instancingSrvIndex;
+	int instancingSrvIndex = 0;
 	// インスタンシングリソース
 	Microsoft::WRL::ComPtr<ID3D12Resource> instancingResource = nullptr;
 	// インスタンス数
@@ -93,7 +93,7 @@ public:
 	 * \param  materialFilePath
 	 * \param  maxInstanceCount
 	 */
-	void CreateParticleGroup(const std::string& name, const std::string& textureFilePath, uint32_t maxInstanceCount);
+	void CreateParticleGroup(const std::string& name, const std::string& textureFilePath/*, uint32_t maxInstanceCount*/);
 
 
 	///--------------------------------------------------------------

--- a/main.cpp
+++ b/main.cpp
@@ -163,7 +163,7 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 	//パーティクルの初期化
 	particle->Initialize(particleSetup.get());
 	//パーティクルグループの作成
-	particle->CreateParticleGroup("Particle", "monsterBall.png", 1);
+	particle->CreateParticleGroup("Particle", "monsterBall.png"/*, 1*/);
 
 	//========================================
 	// パーティクルエミッター
@@ -184,8 +184,6 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 	Transform transformSprite{ {256.0f,256.0f,256.0f},{0.0f,0.0f,0.0f},{0.0f,0.0f,0.0f} };
 	//マテリアル
 	Vector4 materialSprite = sprite->GetColor();
-	//複数枚回転
-	float spritesRotate = 0.01f;
 
 	Transform uvTransformSprite{
 		{1.0f,1.0f,1.0f},


### PR DESCRIPTION
This pull request includes several changes to the `Particle` class and related files to improve code readability and initialization. The most important changes involve commenting out unused parameters and initializing variables with default values.

### Code readability improvements:

* [`engine/2d/Particle.cpp`](diffhunk://#diff-2290d5d92af504a498b8d452b676462b313c0e36321a6132b834998473d42547L151-R160): Commented out the loop and UV coordinate calculations in the `Draw` method to be fixed later.
* [`engine/2d/Particle.cpp`](diffhunk://#diff-2290d5d92af504a498b8d452b676462b313c0e36321a6132b834998473d42547L207-R208): Commented out the `maxInstanceCount` parameter in the `CreateParticleGroup` method definition and call. [[1]](diffhunk://#diff-2290d5d92af504a498b8d452b676462b313c0e36321a6132b834998473d42547L207-R208) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL166-R166)
* [`main.cpp`](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL187-L188): Removed unused variable `spritesRotate` in the `WinMain` function.

### Initialization improvements:

* [`engine/2d/Particle.cpp`](diffhunk://#diff-2290d5d92af504a498b8d452b676462b313c0e36321a6132b834998473d42547L339-R340): Initialized `ParticleStr particle` with empty braces in the `CreateNewParticle` method.
* [`engine/2d/Particle.h`](diffhunk://#diff-a2c17bd5d8bc67fe1ba3e8ff3d6f78b0afc5f21c04b473eb21dad573c9846ab6L50-R54): Initialized `srvIndex`, `particleList`, and `instancingSrvIndex` with default values in the `ParticleGroup` struct.